### PR TITLE
Proper typing for LinkProps.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ import { Children, VNode } from "hyperapp";
 
 /** Link */
 interface LinkProps {
+  class?: string;
   to: string;
   location?: Location;
 }


### PR DESCRIPTION
TS compiler complains without it... So I wasn't being able to add a class to my links as I learned in https://github.com/jorgebucaran/hyperapp-router/issues/86.